### PR TITLE
spec: Fix address nodes listen on

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -8,12 +8,11 @@ function Elasticsearch(n) {
     this.service = new Service("elasticsearch", ref.replicate(n));
 
     if (n > 1) {
-        var hosts = this.service.children();
-        var hostsStr = hosts.join(",");
+        var hosts = this.service.children().join(",");
         this.service.containers.forEach(function(c, i) {
             c.command.push(
-                "--discovery.zen.ping.unicast.hosts", hostsStr,
-                "--network.host", hosts[i]
+                "--discovery.zen.ping.unicast.hosts", hosts,
+                "--network.host", "0.0.0.0"
             );
         });
     }


### PR DESCRIPTION
Before, the spec relied on the order of addresses returned by
`Service.children()` matching the order we create containers. This
assumption no longer holds true with https://github.com/quilt/quilt/commit/29799b5.
We now simply bind to all interfaces.