### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -1,3 +1,5 @@
+const {Container, Service, publicInternet, PortRange} = require("@quilt/quilt");
+
 function Elasticsearch(n) {
     var ref = new Container("elasticsearch:2.4",
         [

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-var Elasticsearch = require("github.com/quilt/elasticsearch").Elasticsearch;
+const {createDeployment, Machine} = require("@quilt/quilt");
+var Elasticsearch = require("./elasticsearch.js").Elasticsearch;
 
 var clusterSize = 2;
 

--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./elasticsearch.js"
+  "name": "@quilt/elasticsearch",
+  "version": "0.0.1",
+  "main": "./elasticsearch.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.