### PR TITLE
elasticsearch: Change `Service.connect` to `Service.allowFrom`

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -30,7 +30,7 @@ Elasticsearch.prototype.allowFromPublic = function allowFromPublic() {
 };
 
 Elasticsearch.prototype.addClient = function addClient(clnt) {
-  clnt.connect(this.port, this.service);
+  this.service.allowFrom(clnt, this.port);
 };
 
 Elasticsearch.prototype.deploy = function deploy(depl) {


### PR DESCRIPTION
cf2f485 missed an instance of `Service.connect`.